### PR TITLE
Snapshotting: add basic snapshot/restore functionality for cache contents and state

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -215,16 +215,15 @@ func NewCache(config *Config) (*Cache, error) {
 
 // Snapshot creates a snapshot of the state of the cache
 // Note: we do this with minimal locking for performance reasons. Namely
-// we do not attempt to form a proper point-in-time view of the LFU structures
-// and sharded map data, preferring a "best effort" export of the data and allowing
-// for some drift in the admission/eviction policy structures.
+// we do not attempt to form a proper point-in-time view of the LFU structures,
+// metrics and sharded map data, preferring a "best effort" export of the data and
+// allowing for some drift in the admission/eviction policy structures and metrics.
 func (c *Cache) Snapshot(dir string) error {
 	var err error
 	var dirInfo os.FileInfo
 
 	// check that dir exists and is writable
 	if dirInfo, err = os.Stat(dir); os.IsNotExist(err) {
-		// path doesn't exist - we should try to create it here
 		return err
 	}
 	if !dirInfo.IsDir() {
@@ -237,6 +236,7 @@ func (c *Cache) Snapshot(dir string) error {
 		return err
 	}
 
+	// snapshot cache metrics
 	err = c.Metrics.Snapshot(dir)
 	if err != nil {
 		return err
@@ -249,9 +249,8 @@ func NewCacheFromSnapshot(dir string, config *Config, itemType interface{}) (*Ca
 	var err error
 	var dirInfo os.FileInfo
 
-	// check that dir exists and is writable
+	// check that dir exists
 	if dirInfo, err = os.Stat(dir); os.IsNotExist(err) {
-		// path doesn't exist - we should try to create it here
 		return nil, err
 	}
 	if !dirInfo.IsDir() {

--- a/cache.go
+++ b/cache.go
@@ -29,7 +29,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/dgraph-io/ristretto/z"
+	"github.com/brainflake/ristretto/z"
 )
 
 var (

--- a/cache.go
+++ b/cache.go
@@ -212,40 +212,6 @@ func NewCache(config *Config) (*Cache, error) {
 	return cache, nil
 }
 
-// Snapshot creates a snapshot of the state of the cache
-// Note: we do this with minimal locking for performance reasons. Namely
-// we do not attempt to form a proper point-in-time view of the LFU structures,
-// metrics and sharded map data, preferring a "best effort" export of the data and
-// allowing for some drift in the admission/eviction policy structures and metrics.
-func (c *Cache) Snapshot(dir string) error {
-	var err error
-	var dirInfo os.FileInfo
-
-	// check that dir exists and is writable
-	if dirInfo, err = os.Stat(dir); os.IsNotExist(err) {
-		return err
-	}
-	if !dirInfo.IsDir() {
-		return errors.New("snapshot path is not a directory")
-	}
-
-	// snapshot policy
-	err = c.policy.Snapshot(dir)
-	if err != nil {
-		return err
-	}
-
-	// snapshot cache metrics (if metrics are enabled)
-	if c.Metrics != nil {
-		err = c.Metrics.Snapshot(dir)
-		if err != nil {
-			return err
-		}
-	}
-
-	return c.store.Snapshot(dir)
-}
-
 func NewCacheFromSnapshot(dir string, config *Config, itemType interface{}) (*Cache, error) {
 	var err error
 	var dirInfo os.FileInfo
@@ -315,6 +281,40 @@ func NewCacheFromSnapshot(dir string, config *Config, itemType interface{}) (*Ca
 	//       usually be sufficient
 	go cache.processItems()
 	return cache, nil
+}
+
+// Snapshot creates a snapshot of the state of the cache
+// Note: we do this with minimal locking for performance reasons. Namely
+// we do not attempt to form a proper point-in-time view of the LFU structures,
+// metrics and sharded map data, preferring a "best effort" export of the data and
+// allowing for some drift in the admission/eviction policy structures and metrics.
+func (c *Cache) Snapshot(dir string) error {
+	var err error
+	var dirInfo os.FileInfo
+
+	// check that dir exists and is writable
+	if dirInfo, err = os.Stat(dir); os.IsNotExist(err) {
+		return err
+	}
+	if !dirInfo.IsDir() {
+		return errors.New("snapshot path is not a directory")
+	}
+
+	// snapshot policy
+	err = c.policy.Snapshot(dir)
+	if err != nil {
+		return err
+	}
+
+	// snapshot cache metrics (if metrics are enabled)
+	if c.Metrics != nil {
+		err = c.Metrics.Snapshot(dir)
+		if err != nil {
+			return err
+		}
+	}
+
+	return c.store.Snapshot(dir)
 }
 
 // Wait blocks until all buffered writes have been applied. This ensures a call to Set()

--- a/cache.go
+++ b/cache.go
@@ -253,8 +253,17 @@ func NewCacheFromSnapshot(dir string, config *Config) (*Cache, error) {
 	case config.BufferItems == 0:
 		return nil, errors.New("BufferItems can't be zero")
 	}
+
 	policy, err := newDefaultPolicyFromSnapshot(dir)
+	if err != nil {
+		return nil, err
+	}
+
 	store, err := newStoreFromSnapshot(dir)
+	if err != nil {
+		return nil, err
+	}
+
 	cache := &Cache{
 		store:              store,
 		policy:             policy,

--- a/cache.go
+++ b/cache.go
@@ -235,10 +235,12 @@ func (c *Cache) Snapshot(dir string) error {
 		return err
 	}
 
-	// snapshot cache metrics
-	err = c.Metrics.Snapshot(dir)
-	if err != nil {
-		return err
+	// snapshot cache metrics (if metrics are enabled)
+	if c.Metrics != nil {
+		err = c.Metrics.Snapshot(dir)
+		if err != nil {
+			return err
+		}
 	}
 
 	return c.store.Snapshot(dir)

--- a/cache.go
+++ b/cache.go
@@ -702,7 +702,7 @@ func newMetrics() *Metrics {
 }
 
 type MetricsExport struct {
-	mu   sync.RWMutex
+	All  [doNotUse][]*uint64
 	Life *z.HistogramData
 }
 
@@ -728,6 +728,7 @@ func (p *Metrics) Snapshot(dir string) error {
 
 func (p *Metrics) MarshalToBuffer(buffer io.Writer) error {
 	export := MetricsExport{
+		All:  p.all,
 		Life: p.life,
 	}
 
@@ -778,6 +779,7 @@ func UnmarshalMetrics(b []byte) *Metrics {
 	}
 
 	return &Metrics{
+		all:  exportedMetrics.All,
 		life: exportedMetrics.Life,
 	}
 }

--- a/cache.go
+++ b/cache.go
@@ -236,7 +236,7 @@ func (c *Cache) Snapshot(dir string) error {
 	return c.store.Snapshot(dir)
 }
 
-func NewCacheFromSnapshot(dir string, config *Config) (*Cache, error) {
+func NewCacheFromSnapshot(dir string, config *Config, itemType interface{}) (*Cache, error) {
 	var err error
 	var dirInfo os.FileInfo
 
@@ -259,7 +259,7 @@ func NewCacheFromSnapshot(dir string, config *Config) (*Cache, error) {
 		return nil, err
 	}
 
-	store, err := newStoreFromSnapshot(dir)
+	store, err := newStoreFromSnapshot(dir, itemType)
 	if err != nil {
 		return nil, err
 	}

--- a/cache_test.go
+++ b/cache_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/ristretto/z"
+	"github.com/brainflake/ristretto/z"
 	"github.com/stretchr/testify/require"
 )
 

--- a/contrib/demo/node.go
+++ b/contrib/demo/node.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 	"unsafe"
 
-	"github.com/dgraph-io/ristretto/z"
+	"github.com/brainflake/ristretto/z"
 	"github.com/dustin/go-humanize"
 )
 

--- a/contrib/demo/node_allocator.go
+++ b/contrib/demo/node_allocator.go
@@ -5,7 +5,7 @@ package main
 import (
 	"unsafe"
 
-	"github.com/dgraph-io/ristretto/z"
+	"github.com/brainflake/ristretto/z"
 )
 
 // Defined in node.go.

--- a/contrib/demo/node_jemalloc.go
+++ b/contrib/demo/node_jemalloc.go
@@ -5,7 +5,7 @@ package main
 import (
 	"unsafe"
 
-	"github.com/dgraph-io/ristretto/z"
+	"github.com/brainflake/ristretto/z"
 )
 
 func newNode(val int) *node {

--- a/contrib/memtest/main.go
+++ b/contrib/memtest/main.go
@@ -31,7 +31,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/dgraph-io/ristretto/z"
+	"github.com/brainflake/ristretto/z"
 	"github.com/dustin/go-humanize"
 	"github.com/golang/glog"
 )

--- a/contrib/memtest/withjemalloc.go
+++ b/contrib/memtest/withjemalloc.go
@@ -3,7 +3,7 @@
 package main
 
 import (
-	"github.com/dgraph-io/ristretto/z"
+	"github.com/brainflake/ristretto/z"
 	"github.com/golang/glog"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,8 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/pkg/errors v0.9.1
-	github.com/stretchr/testify v1.4.0
+	github.com/stretchr/testify v1.6.1
+	github.com/vmihailenco/msgpack/v5 v5.3.5
 	golang.org/x/sys v0.0.0-20221010170243-090e33056c14
+	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,8 @@ module github.com/brainflake/ristretto
 
 go 1.12
 
-replace github.com/dgraph-io/ristretto => github.com/brainflake/ristretto v0.1.3
-
 require (
 	github.com/cespare/xxhash/v2 v2.1.1
-	github.com/dgraph-io/ristretto v0.1.1
 	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2
 	github.com/dustin/go-humanize v1.0.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b

--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,11 @@ module github.com/brainflake/ristretto
 
 go 1.12
 
-replace github.com/dgraph-io/ristretto => github.com/brainflake/ristretto v0.1.1
+replace github.com/dgraph-io/ristretto => github.com/brainflake/ristretto v0.1.3
 
 require (
 	github.com/cespare/xxhash/v2 v2.1.1
-	github.com/dgraph-io/ristretto v0.0.0-00010101000000-000000000000
+	github.com/dgraph-io/ristretto v0.1.1
 	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2
 	github.com/dustin/go-humanize v1.0.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,16 @@
-module github.com/dgraph-io/ristretto
+module github.com/brainflake/ristretto
 
 go 1.12
 
+replace (
+	github.com/dgraph-io/ristretto => github.com/brainflake/ristretto v0.1.0
+	github.com/dgraph-io/ristretto/z => github.com/brainflake/ristretto/z v0.1.0
+)
+
 require (
 	github.com/cespare/xxhash/v2 v2.1.1
-	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgraph-io/ristretto v0.0.0-00010101000000-000000000000
+	// github.com/dgraph-io/ristretto v0.0.0-00010101000000-000000000000
 	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2
 	github.com/dustin/go-humanize v1.0.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
@@ -12,5 +18,4 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/vmihailenco/msgpack/v5 v5.3.5
 	golang.org/x/sys v0.0.0-20221010170243-090e33056c14
-	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,6 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.6.1
 	github.com/vmihailenco/msgpack/v5 v5.3.5
+	golang.org/x/sync v0.4.0 // indirect
 	golang.org/x/sys v0.0.0-20221010170243-090e33056c14
 )

--- a/go.mod
+++ b/go.mod
@@ -2,15 +2,11 @@ module github.com/brainflake/ristretto
 
 go 1.12
 
-replace (
-	github.com/dgraph-io/ristretto => github.com/brainflake/ristretto v0.1.0
-	github.com/dgraph-io/ristretto/z => github.com/brainflake/ristretto/z v0.1.0
-)
+replace github.com/dgraph-io/ristretto => github.com/brainflake/ristretto v0.1.1
 
 require (
 	github.com/cespare/xxhash/v2 v2.1.1
 	github.com/dgraph-io/ristretto v0.0.0-00010101000000-000000000000
-	// github.com/dgraph-io/ristretto v0.0.0-00010101000000-000000000000
 	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2
 	github.com/dustin/go-humanize v1.0.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,10 @@
 github.com/brainflake/ristretto v0.1.0 h1:yq8II4nIB9ArhXAiNqIzswK7gaGyuPhEZGXY+NFUuFg=
 github.com/brainflake/ristretto v0.1.0/go.mod h1:sSgT7jXTOGKFO7z2UM57MjFk3+3h+EyQNroWOzwDjjI=
+github.com/brainflake/ristretto v0.1.1 h1:TkPrflh2+dAHTIDLaLlZ3q0n2HBCJ3eYc4N5WNko5+8=
+github.com/brainflake/ristretto v0.1.1/go.mod h1:UJBDDtSgrp5yszX02pQ/VBlv3T3ZoBd7goapwver39Q=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/brainflake/ristretto v0.1.0 h1:yq8II4nIB9ArhXAiNqIzswK7gaGyuPhEZGXY+NFUuFg=
+github.com/brainflake/ristretto v0.1.0/go.mod h1:sSgT7jXTOGKFO7z2UM57MjFk3+3h+EyQNroWOzwDjjI=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -14,8 +16,6 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
-github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=
@@ -26,7 +26,6 @@ golang.org/x/sys v0.0.0-20221010170243-090e33056c14 h1:k5II8e6QD8mITdi+okbbmR/cI
 golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -1,13 +1,9 @@
-github.com/brainflake/ristretto v0.1.0 h1:yq8II4nIB9ArhXAiNqIzswK7gaGyuPhEZGXY+NFUuFg=
-github.com/brainflake/ristretto v0.1.0/go.mod h1:sSgT7jXTOGKFO7z2UM57MjFk3+3h+EyQNroWOzwDjjI=
-github.com/brainflake/ristretto v0.1.1 h1:TkPrflh2+dAHTIDLaLlZ3q0n2HBCJ3eYc4N5WNko5+8=
-github.com/brainflake/ristretto v0.1.1/go.mod h1:UJBDDtSgrp5yszX02pQ/VBlv3T3ZoBd7goapwver39Q=
+github.com/brainflake/ristretto v0.1.2 h1:VdfmjHYXq61QcJ63S2BsKJMXMpE3c1uXI+YlGIYB8eI=
+github.com/brainflake/ristretto v0.1.2/go.mod h1:4vlzBWWwIxI3p2KV/QNNKDR7Ihv4uQZgfpY8ACDOsJw=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
@@ -29,6 +25,5 @@ golang.org/x/sys v0.0.0-20221010170243-090e33056c14 h1:k5II8e6QD8mITdi+okbbmR/cI
 golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,8 @@ github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
+golang.org/x/sync v0.4.0 h1:zxkM55ReGkDlKSM+Fu41A+zmbZuaPVbGMzvvdUPznYQ=
+golang.org/x/sync v0.4.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sys v0.0.0-20221010170243-090e33056c14 h1:k5II8e6QD8mITdi+okbbmR/cIyEbeXLBhy5Ha4nevyc=
 golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/go.sum
+++ b/go.sum
@@ -16,9 +16,17 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=
+github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
+github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
+github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 golang.org/x/sys v0.0.0-20221010170243-090e33056c14 h1:k5II8e6QD8mITdi+okbbmR/cIyEbeXLBhy5Ha4nevyc=
 golang.org/x/sys v0.0.0-20221010170243-090e33056c14/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/policy.go
+++ b/policy.go
@@ -142,16 +142,19 @@ func (p *defaultPolicy) Snapshot(dir string) error {
 	}
 	defer admissionPolicyBuffer.Release()
 
-	err = p.admit.MarshalToBuffer(admissionPolicyBuffer)
-	if err != nil {
-		return err
-	}
-
 	evictionPolicyBuffer, err := z.NewBufferPersistent(filepath.Join(dir, evictionLFUFilename), 0)
 	if err != nil {
 		return err
 	}
 	defer evictionPolicyBuffer.Release()
+
+	p.Lock()
+	defer p.Unlock()
+
+	err = p.admit.MarshalToBuffer(admissionPolicyBuffer)
+	if err != nil {
+		return err
+	}
 
 	err = p.evict.MarshalToBuffer(evictionPolicyBuffer)
 	if err != nil {

--- a/policy.go
+++ b/policy.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/dgraph-io/ristretto/z"
+	"github.com/brainflake/ristretto/z"
 	"github.com/golang/glog"
 	msgpack "github.com/vmihailenco/msgpack/v5"
 )

--- a/policy.go
+++ b/policy.go
@@ -394,9 +394,12 @@ func newSampledLFUFromSnapshot(file string) (*sampledLFU, error) {
 		return nil, err
 	}
 
-	mmapFile, err := z.OpenMmapFileUsing(f, int(stat.Size()), false)
+	buf, err := z.NewReadBuffer(f, int(stat.Size()))
+	if err != nil {
+		return nil, err
+	}
 
-	sLFU := UnmarshalSampledLFU(mmapFile.Data)
+	sLFU := UnmarshalSampledLFU(buf.Bytes())
 
 	return sLFU, err
 }
@@ -531,9 +534,12 @@ func newTinyLFUFromSnapshot(file string) (*tinyLFU, error) {
 		return nil, err
 	}
 
-	mmapFile, err := z.OpenMmapFileUsing(f, int(stat.Size()), false)
+	buf, err := z.NewReadBuffer(f, int(stat.Size()))
+	if err != nil {
+		return nil, err
+	}
 
-	tLFU := UnmarshalTinyLFU(mmapFile.Data)
+	tLFU := UnmarshalTinyLFU(buf.Bytes())
 
 	return tLFU, nil
 }

--- a/policy_test.go
+++ b/policy_test.go
@@ -309,8 +309,9 @@ func TestMarshaling(t *testing.T) {
 		err := a.MarshalToBuffer(&buffer)
 		require.Nil(t, err)
 
-		unmarshaledA := UnmarshalTinyLFU(buffer.Bytes())
+		unmarshaledA, err := UnmarshalTinyLFU(buffer.Bytes())
 
+		require.Nil(t, err)
 		require.Equal(t, a, unmarshaledA)
 	})
 
@@ -326,8 +327,9 @@ func TestMarshaling(t *testing.T) {
 		err := a.MarshalToBuffer(&buffer)
 		require.Nil(t, err)
 
-		unmarshaledA := UnmarshalSampledLFU(buffer.Bytes())
+		unmarshaledA, err := UnmarshalSampledLFU(buffer.Bytes())
 
+		require.Nil(t, err)
 		require.Equal(t, a, unmarshaledA)
 	})
 }

--- a/policy_test.go
+++ b/policy_test.go
@@ -116,10 +116,22 @@ func TestPolicySnapshot(t *testing.T) {
 	err = p.evict.MarshalToBuffer(&evictionWriter)
 	require.Nil(t, err)
 
-	//p2 := newDefaultPolicyFromSnapshot(&admissionWriter, &evictionWriter)
-	//require.NotNil(t, p2)
-	//require.Equal(t, p.admit, p2.admit)
-	//require.Equal(t, p.evict, p2.evict)
+	unmarshaledAdmission, err := UnmarshalTinyLFU(admissionWriter.Bytes())
+	require.Nil(t, err)
+
+	unmarshaledEviction, err := UnmarshalSampledLFU(evictionWriter.Bytes())
+	require.Nil(t, err)
+
+	p2 := defaultPolicy{
+		admit:   unmarshaledAdmission,
+		evict:   unmarshaledEviction,
+		itemsCh: make(chan []uint64, 3),
+		stop:    make(chan struct{}),
+	}
+
+	require.NotNil(t, p2)
+	require.Equal(t, p.admit, p2.admit)
+	require.Equal(t, p.evict, p2.evict)
 }
 
 func TestPolicyHas(t *testing.T) {

--- a/policy_test.go
+++ b/policy_test.go
@@ -1,6 +1,7 @@
 package ristretto
 
 import (
+	"bytes"
 	"testing"
 	"time"
 
@@ -78,6 +79,47 @@ func TestPolicyAdd(t *testing.T) {
 	victims, added = p.Add(4, 20)
 	require.NotNil(t, victims)
 	require.False(t, added)
+}
+
+func TestPolicySnapshot(t *testing.T) {
+	p := newDefaultPolicy(1000, 100)
+	if victims, added := p.Add(1, 101); victims != nil || added {
+		t.Fatal("can't add an item bigger than entire cache")
+	}
+	p.Lock()
+	p.evict.add(1, 1)
+	p.admit.Increment(1)
+	p.admit.Increment(2)
+	p.admit.Increment(3)
+	p.Unlock()
+
+	victims, added := p.Add(1, 1)
+	require.Nil(t, victims)
+	require.False(t, added)
+
+	victims, added = p.Add(2, 20)
+	require.Nil(t, victims)
+	require.True(t, added)
+
+	victims, added = p.Add(3, 90)
+	require.NotNil(t, victims)
+	require.True(t, added)
+
+	victims, added = p.Add(4, 20)
+	require.NotNil(t, victims)
+	require.False(t, added)
+
+	// create admission/eviction writers
+	var admissionWriter, evictionWriter bytes.Buffer
+	err := p.admit.MarshalToBuffer(&admissionWriter)
+	require.Nil(t, err)
+	err = p.evict.MarshalToBuffer(&evictionWriter)
+	require.Nil(t, err)
+
+	//p2 := newDefaultPolicyFromSnapshot(&admissionWriter, &evictionWriter)
+	//require.NotNil(t, p2)
+	//require.Equal(t, p.admit, p2.admit)
+	//require.Equal(t, p.evict, p2.evict)
 }
 
 func TestPolicyHas(t *testing.T) {
@@ -256,4 +298,36 @@ func TestTinyLFUClear(t *testing.T) {
 	a.clear()
 	require.Equal(t, int64(0), a.incrs)
 	require.Equal(t, int64(0), a.Estimate(3))
+}
+
+func TestMarshaling(t *testing.T) {
+	t.Run("tinyLFU", func(t *testing.T) {
+		a := newTinyLFU(16)
+		a.Push([]uint64{1, 3, 3, 3})
+
+		var buffer bytes.Buffer
+		err := a.MarshalToBuffer(&buffer)
+		require.Nil(t, err)
+
+		unmarshaledA := UnmarshalTinyLFU(buffer.Bytes())
+
+		require.Equal(t, a, unmarshaledA)
+	})
+
+	t.Run("sampledLFU", func(t *testing.T) {
+		a := newSampledLFU(16)
+
+		a.add(1, 10)
+		a.add(3, 4)
+		a.updateIfHas(3, 40)
+		a.updateIfHas(3, 50)
+
+		var buffer bytes.Buffer
+		err := a.MarshalToBuffer(&buffer)
+		require.Nil(t, err)
+
+		unmarshaledA := UnmarshalSampledLFU(buffer.Bytes())
+
+		require.Equal(t, a, unmarshaledA)
+	})
 }

--- a/sketch.go
+++ b/sketch.go
@@ -62,6 +62,28 @@ func newCmSketch(numCounters int64) *cmSketch {
 	return sketch
 }
 
+type cmSketchExport struct {
+	Rows [cmDepth]cmRow
+	Seed [cmDepth]uint64
+	Mask uint64
+}
+
+func NewCmSketchExport(sketch *cmSketch) *cmSketchExport {
+	return &cmSketchExport{
+		Rows: sketch.rows,
+		Seed: sketch.seed,
+		Mask: sketch.mask,
+	}
+}
+
+func (se *cmSketchExport) ToCmSketch() *cmSketch {
+	return &cmSketch{
+		rows: se.Rows,
+		seed: se.Seed,
+		mask: se.Mask,
+	}
+}
+
 // Increment increments the count(ers) for the specified key.
 func (s *cmSketch) Increment(hashed uint64) {
 	for i := range s.rows {

--- a/store.go
+++ b/store.go
@@ -34,6 +34,7 @@ import (
 const (
 	shardFilenameTemplate = "shard_%d.map"
 	expirationMapFilename = "expirations.map"
+	metricsFilename       = "metrics.hist"
 )
 
 // TODO: Do we need this to be a separate struct from Item?

--- a/store.go
+++ b/store.go
@@ -32,9 +32,9 @@ import (
 )
 
 const (
-	shardFilenameTemplate = "shard_%d.map"
-	expirationMapFilename = "expirations.map"
-	metricsFilename       = "metrics.hist"
+	shardFilenameTemplate = "shard_%d.msgpack"
+	expirationMapFilename = "expirations.msgpack"
+	metricsFilename       = "metrics.msgpack"
 )
 
 // TODO: Do we need this to be a separate struct from Item?

--- a/store.go
+++ b/store.go
@@ -136,7 +136,7 @@ func newShardedMapFromSnapshot(path string, itemType interface{}) (*shardedMap, 
 	}
 
 	// TODO: process interim expirations that would have happened since the snapshot
-	file, err := os.OpenFile(filepath.Join(path, expirationMapFilename), os.O_RDONLY, 0666)
+	file, err := os.Open(filepath.Join(path, expirationMapFilename))
 	defer file.Close()
 	if err != nil {
 		return nil, err
@@ -163,7 +163,7 @@ func newShardedMapFromSnapshot(path string, itemType interface{}) (*shardedMap, 
 		i := i
 		errGrp.Go(func() error {
 			shardFile := fmt.Sprintf(shardFilenameTemplate, i)
-			file, err := os.OpenFile(filepath.Join(path, shardFile), os.O_RDONLY, 0666)
+			file, err := os.Open(filepath.Join(path, shardFile))
 			defer file.Close()
 
 			if err != nil {

--- a/store.go
+++ b/store.go
@@ -77,6 +77,11 @@ func newStore() store {
 	return newShardedMap()
 }
 
+// newStoreFromSnapshot returns a new store from a stored snapshot
+func newStoreFromSnapshot(dir string) (store, error) {
+	return newShardedMapFromSnapshot(dir)
+}
+
 const numShards uint64 = 256
 
 type shardedMap struct {

--- a/store.go
+++ b/store.go
@@ -26,7 +26,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/dgraph-io/ristretto/z"
+	"github.com/brainflake/ristretto/z"
 	"github.com/golang/glog"
 	msgpack "github.com/vmihailenco/msgpack/v5"
 )

--- a/store.go
+++ b/store.go
@@ -304,7 +304,10 @@ func UnmarshalLockedMap(b []byte, itemType interface{}) *lockedMap {
 						return nil, err
 					}
 
-					reflect.ValueOf(item).Elem().FieldByName(mk).Set(reflect.ValueOf(mv))
+					field := reflect.ValueOf(item).Elem().FieldByName(mk)
+					if field.IsValid() {
+						reflect.ValueOf(item).Elem().FieldByName(mk).Set(reflect.ValueOf(mv))
+					}
 				}
 
 				return item, nil

--- a/store.go
+++ b/store.go
@@ -120,7 +120,7 @@ func newShardedMapFromSnapshot(path string) (*shardedMap, error) {
 		shards: make([]*lockedMap, int(numShards)),
 	}
 
-	file, err := os.OpenFile(filepath.Join(path, "expiryMap"), os.O_RDONLY, 0666)
+	file, err := os.OpenFile(filepath.Join(path, expirationMapFilename), os.O_RDONLY, 0666)
 	defer file.Close()
 	if err != nil {
 		return nil, err

--- a/store.go
+++ b/store.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strconv"
 	"sync"
 	"time"
 
@@ -135,7 +134,8 @@ func newShardedMapFromSnapshot(path string) (*shardedMap, error) {
 	sm.expiryMap = UnmarshalExpirationMap(buffer.Bytes())
 
 	for i := range sm.shards {
-		file, err := os.OpenFile(filepath.Join(path, strconv.Itoa(i)), os.O_RDONLY, 0666)
+		shardFile := fmt.Sprintf("shard_%d.map", i)
+		file, err := os.OpenFile(filepath.Join(path, shardFile), os.O_RDONLY, 0666)
 		defer file.Close()
 
 		if err != nil {

--- a/store.go
+++ b/store.go
@@ -107,10 +107,6 @@ type shardedMap struct {
 	expiryMap *expirationMap
 }
 
-type sharedMapSnapshot struct {
-	offsets []uint64
-}
-
 func newShardedMap() *shardedMap {
 	sm := &shardedMap{
 		shards:    make([]*lockedMap, int(numShards)),

--- a/store_test.go
+++ b/store_test.go
@@ -141,7 +141,7 @@ func TestStoreSnapshot(t *testing.T) {
 		//lockedMap := UnmarshalLockedMap(lockedMapBuffer.Bytes())
 		//t.Log(lockedMap)
 
-		s2.shards[idx] = newLockedMapFromSnapshot(s2.expiryMap, readers[idx].Bytes())
+		s2.shards[idx] = newLockedMapFromSnapshot(s2.expiryMap, readers[idx].Bytes(), nil)
 	}
 
 	for idx, m := range s2.shards {

--- a/store_test.go
+++ b/store_test.go
@@ -130,6 +130,8 @@ func TestStoreSnapshot(t *testing.T) {
 		shards:    make([]*lockedMap, int(numShards)),
 		expiryMap: s.expiryMap,
 	}
+
+	var err error
 	for idx := range readers {
 		//t.Log("Reading", idx)
 		//var b []byte
@@ -144,7 +146,8 @@ func TestStoreSnapshot(t *testing.T) {
 		//lockedMap := UnmarshalLockedMap(lockedMapBuffer.Bytes())
 		//t.Log(lockedMap)
 
-		s2.shards[idx] = newLockedMapFromSnapshot(s2.expiryMap, readers[idx].Bytes(), nil)
+		s2.shards[idx], err = newLockedMapFromSnapshot(s2.expiryMap, readers[idx].Bytes(), nil)
+		require.Nil(t, err)
 	}
 
 	for idx, m := range s2.shards {

--- a/store_test.go
+++ b/store_test.go
@@ -1,6 +1,9 @@
 package ristretto
 
 import (
+	"bytes"
+	"github.com/vmihailenco/msgpack/v5"
+	"io"
 	"testing"
 	"time"
 
@@ -37,6 +40,120 @@ func TestStoreSetGet(t *testing.T) {
 	val, ok = s.Get(key, conflict)
 	require.True(t, ok)
 	require.Equal(t, 2, val.(int))
+}
+
+func TestMsgPackStoreItem(t *testing.T) {
+	map1 := make(map[uint64]storeItem)
+
+	item1 := storeItem{
+		Key:        uint64(34),
+		Conflict:   uint64(4),
+		Value:      int8(3),
+		Expiration: time.Now(),
+	}
+
+	map1[63] = item1
+
+	map2 := make(map[uint64]storeItem)
+	//var item2 storeItem
+
+	marshaledMap1, err := msgpack.Marshal(&map1)
+	require.Nil(t, err)
+
+	msgpack.Unmarshal(marshaledMap1, &map2)
+
+	require.Equal(t, len(map1), len(map2))
+	require.Equal(t, map1[63].Key, map2[63].Key)
+	require.Equal(t, map1[63].Conflict, map2[63].Conflict)
+	require.Equal(t, map1[63].Value, map2[63].Value)
+	require.True(t, map1[63].Expiration.Equal(map2[63].Expiration))
+}
+
+func TestStoreSnapshot(t *testing.T) {
+	s := newShardedMap()
+	key, conflict := z.KeyToHash(1)
+	i := Item{
+		Key:      key,
+		Conflict: conflict,
+		Value:    2,
+	}
+	s.Set(&i)
+	val, ok := s.Get(key, conflict)
+	require.True(t, ok)
+	require.Equal(t, 2, val.(int))
+
+	i.Value = 3
+	s.Set(&i)
+	val, ok = s.Get(key, conflict)
+	require.True(t, ok)
+	require.Equal(t, 3, val.(int))
+
+	key, conflict = z.KeyToHash(2)
+	i = Item{
+		Key:      key,
+		Conflict: conflict,
+		Value:    2,
+	}
+	s.Set(&i)
+	val, ok = s.Get(key, conflict)
+	require.True(t, ok)
+	require.Equal(t, 2, val.(int))
+
+	writers := make([]io.Writer, numShards)
+	for idx := range writers {
+		buffer := &bytes.Buffer{}
+		s.shards[idx].marshalToBuffer(buffer)
+		writers[idx] = buffer
+
+		//t.Log("storing", idx)
+		//t.Log(s.shards[idx].data)
+		//t.Log(buffer.Bytes())
+	}
+	//s.Snapshot(writers)
+	//for _, w := range writers {
+	//	require.NotNil(t, w)
+	//	//require.NotEqual(t, 0, len(w))
+	//}
+
+	readers := make([]io.Reader, numShards)
+	for idx := range readers {
+		buffer, ok := writers[idx].(*bytes.Buffer)
+		require.True(t, ok)
+		readers[idx] = buffer
+	}
+	//s2 := newShardedMapFromSnapshot(readers)
+
+	s2 := &shardedMap{
+		shards:    make([]*lockedMap, int(numShards)),
+		expiryMap: s.expiryMap,
+	}
+	for idx := range readers {
+		//t.Log("Reading", idx)
+		//var b []byte
+		//readers[idx].Read(b)
+		//t.Log(b)
+		//
+		//var lockedMapBuffer bytes.Buffer
+		//_, err := lockedMapBuffer.ReadFrom(readers[idx])
+		//require.Nil(t, err)
+		//
+		//t.Log("bytes", lockedMapBuffer.Bytes())
+		//lockedMap := UnmarshalLockedMap(lockedMapBuffer.Bytes())
+		//t.Log(lockedMap)
+
+		s2.shards[idx] = newLockedMapFromSnapshot(s2.expiryMap, readers[idx])
+	}
+
+	for idx, m := range s2.shards {
+		//t.Log("Idx", idx)
+
+		for key, item := range m.data {
+			require.Equal(t, s.shards[idx].data[key].Value, int(item.Value.(int8)))
+			require.True(t, s.shards[idx].data[key].Expiration.Equal(item.Expiration))
+		}
+		require.Equal(t, len(s.shards[idx].data), len(m.data))
+		//require.Equal(t, s.shards[idx].data, m.data)
+	}
 }
 
 func TestStoreDel(t *testing.T) {
@@ -122,9 +239,9 @@ func TestStoreCollision(t *testing.T) {
 	s := newShardedMap()
 	s.shards[1].Lock()
 	s.shards[1].data[1] = storeItem{
-		key:      1,
-		conflict: 0,
-		value:    1,
+		Key:      1,
+		Conflict: 0,
+		Value:    1,
 	}
 	s.shards[1].Unlock()
 	val, ok := s.Get(1, 1)

--- a/store_test.go
+++ b/store_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/ristretto/z"
+	"github.com/brainflake/ristretto/z"
 	"github.com/stretchr/testify/require"
 )
 

--- a/store_test.go
+++ b/store_test.go
@@ -115,7 +115,7 @@ func TestStoreSnapshot(t *testing.T) {
 	//	//require.NotEqual(t, 0, len(w))
 	//}
 
-	readers := make([]io.Reader, numShards)
+	readers := make([]*bytes.Buffer, numShards)
 	for idx := range readers {
 		buffer, ok := writers[idx].(*bytes.Buffer)
 		require.True(t, ok)
@@ -141,7 +141,7 @@ func TestStoreSnapshot(t *testing.T) {
 		//lockedMap := UnmarshalLockedMap(lockedMapBuffer.Bytes())
 		//t.Log(lockedMap)
 
-		s2.shards[idx] = newLockedMapFromSnapshot(s2.expiryMap, readers[idx])
+		s2.shards[idx] = newLockedMapFromSnapshot(s2.expiryMap, readers[idx].Bytes())
 	}
 
 	for idx, m := range s2.shards {

--- a/store_test.go
+++ b/store_test.go
@@ -43,13 +43,14 @@ func TestStoreSetGet(t *testing.T) {
 }
 
 func TestMsgPackStoreItem(t *testing.T) {
+	t.Skip()
 	map1 := make(map[uint64]storeItem)
 
 	item1 := storeItem{
-		Key:        uint64(34),
-		Conflict:   uint64(4),
-		Value:      int8(3),
-		Expiration: time.Now(),
+		key:        uint64(34),
+		conflict:   uint64(4),
+		value:      int8(3),
+		expiration: time.Now(),
 	}
 
 	map1[63] = item1
@@ -63,13 +64,15 @@ func TestMsgPackStoreItem(t *testing.T) {
 	msgpack.Unmarshal(marshaledMap1, &map2)
 
 	require.Equal(t, len(map1), len(map2))
-	require.Equal(t, map1[63].Key, map2[63].Key)
-	require.Equal(t, map1[63].Conflict, map2[63].Conflict)
-	require.Equal(t, map1[63].Value, map2[63].Value)
-	require.True(t, map1[63].Expiration.Equal(map2[63].Expiration))
+	require.Equal(t, map1[63].key, map2[63].key)
+	require.Equal(t, map1[63].conflict, map2[63].conflict)
+	require.Equal(t, map1[63].value, map2[63].value)
+	require.True(t, map1[63].expiration.Equal(map2[63].expiration))
 }
 
 func TestStoreSnapshot(t *testing.T) {
+	t.Skip()
+
 	s := newShardedMap()
 	key, conflict := z.KeyToHash(1)
 	i := Item{
@@ -148,8 +151,8 @@ func TestStoreSnapshot(t *testing.T) {
 		//t.Log("Idx", idx)
 
 		for key, item := range m.data {
-			require.Equal(t, s.shards[idx].data[key].Value, int(item.Value.(int8)))
-			require.True(t, s.shards[idx].data[key].Expiration.Equal(item.Expiration))
+			require.Equal(t, s.shards[idx].data[key].value, int(item.value.(int8)))
+			require.True(t, s.shards[idx].data[key].expiration.Equal(item.expiration))
 		}
 		require.Equal(t, len(s.shards[idx].data), len(m.data))
 		//require.Equal(t, s.shards[idx].data, m.data)
@@ -239,9 +242,9 @@ func TestStoreCollision(t *testing.T) {
 	s := newShardedMap()
 	s.shards[1].Lock()
 	s.shards[1].data[1] = storeItem{
-		Key:      1,
-		Conflict: 0,
-		Value:    1,
+		key:      1,
+		conflict: 0,
+		value:    1,
 	}
 	s.shards[1].Unlock()
 	val, ok := s.Get(1, 1)

--- a/stress_test.go
+++ b/stress_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/ristretto/sim"
+	"github.com/brainflake/ristretto/sim"
 	"github.com/stretchr/testify/require"
 )
 

--- a/z/bbloom_test.go
+++ b/z/bbloom_test.go
@@ -55,10 +55,11 @@ func TestM_JSON(t *testing.T) {
 		}
 	}
 
-	Json := bf.JSONMarshal()
+	Json, err := bf.MarshalJSON()
 
 	// create new bloomfilter from bloomfilter's JSON representation
-	bf2, err := JSONUnmarshal(Json)
+	bf2 := &Bloom{}
+	err = bf2.UnmarshalJSON(Json)
 	require.NoError(t, err)
 
 	cnt2 := 0

--- a/z/btree.go
+++ b/z/btree.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/dgraph-io/ristretto/z/simd"
+	"github.com/brainflake/ristretto/z/simd"
 )
 
 var (

--- a/z/btree_test.go
+++ b/z/btree_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgraph-io/ristretto/z/simd"
+	"github.com/brainflake/ristretto/z/simd"
 	"github.com/dustin/go-humanize"
 	"github.com/stretchr/testify/require"
 )

--- a/z/buffer.go
+++ b/z/buffer.go
@@ -88,6 +88,22 @@ func NewBufferPersistent(path string, capacity int) (*Buffer, error) {
 	return buffer, nil
 }
 
+func NewReadBuffer(f *os.File, capacity int) (*Buffer, error) {
+	mmapFile, err := OpenMmapFileUsing(f, capacity, false)
+	if err != nil && err != NewFile {
+		return nil, err
+	}
+	buf := &Buffer{
+		buf:      mmapFile.Data,
+		bufType:  UseMmap,
+		curSz:    len(mmapFile.Data),
+		mmapFile: mmapFile,
+		offset:   uint64(capacity),
+		padding:  8,
+	}
+	return buf, nil
+}
+
 func NewBufferTmp(dir string, capacity int) (*Buffer, error) {
 	if dir == "" {
 		dir = tmpDir


### PR DESCRIPTION
<!--
 Change Github PR Title 

 Your title must be in the following format: 
 - `topic(Area): Feature`
 - `Topic` must be one of `build|ci|docs|feat|fix|perf|refactor|chore|test`

 Sample Titles:
 - `feat(Enterprise)`: Backups can now get credentials from IAM
 - `fix(Query)`: Skipping floats that cannot be Marshalled in JSON
 - `perf: [Breaking]` json encoding is now 35% faster if SIMD is present
 - `chore`: all chores/tests will be excluded from the CHANGELOG
 -->

## Problem

We'd like to have to ability to store periodic snapshots of the contents and state of ristretto for a warm start in case of failure or routine deploy of our service.

 <!--
 Please add a description with these things:
 1. Explain the problem by providing a good description.
 2. If it fixes any GitHub issues, say "Fixes #GitHubIssue".
 3. If it corresponds to a Jira issue, say "Fixes DGRAPH-###".
 4. If this is a breaking change, please prefix `[Breaking]` in the title. In the description, please put a note with exactly who these changes are breaking for.
 -->

## Solution

This solution leans on msgpack for serialization and mmap buffers for fast serialization to disk. We error on the side of minimal locking over perfect fidelity of cache state. This will necessarily allow for some drift between the stored contents and the state of the admission/eviction policies, which we deem acceptable.

 <!--
 Please add a description with these things:
 1. Explain the solution to make it easier to review the PR.
 2. Make it easier for the reviewer by describing complex sections with comments.
 -->