### PR TITLE
sampledLFU: ensure we set maxCost from config when initializing from snapshot

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -229,7 +229,7 @@ func NewCacheFromSnapshot(dir string, config *Config, itemType interface{}) (*Ca
 		return nil, errors.New("BufferItems can't be zero")
 	}
 
-	policy, err := newDefaultPolicyFromSnapshot(dir)
+	policy, err := newDefaultPolicyFromSnapshot(dir, config.MaxCost)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Problem
When restoring from snapshot, the maxCost is preserved from the stored state. This prevents a size increase across restarts in snapshot restore mode.

## Solution
Initialize the maxCost properly when unmarshaling the sampledLFU state.